### PR TITLE
Feature/moc infra

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -4,3 +4,7 @@ os_base_domain: cnv2.massopen.cloud
 os_vip_api: 192.12.185.141
 os_vip_ingress: 192.12.185.143
 os_vip_dns: 192.12.185.142
+
+dnsmasq_extra_config: |
+  host-record=api.ocp4-aio.cnv2.massopen.cloud,192.12.185.21
+  address=/apps.ocp4-aio.cnv2.massopen.cloud/192.12.185.22

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -1,6 +1,6 @@
 ---
-os_cluster_name: ilana-cnv
-os_base_domain: cnv2.massopen.cloud
+os_cluster_name: moc-infra
+os_base_domain: moc-infra.massopen.cloud
 os_vip_api: 192.12.185.141
 os_vip_ingress: 192.12.185.143
 os_vip_dns: 192.12.185.142

--- a/hosts.yml
+++ b/hosts.yml
@@ -23,29 +23,33 @@ all:
         ansible_user: core
         ansible_python_interpreter: /usr/libexec/platform-python
         manage_dns: true
-      hosts:
-        openshift-master-0.cnv2.massopen.cloud:
-          ipmi_host: 10.0.15.2
-          baremetal_ip: 192.12.185.145
-          baremetal_mac: d4:ae:52:94:d5:a5
-          provisioning_mac: d4:ae:52:94:d5:a3
-        openshift-master-1.cnv2.massopen.cloud:
-          ipmi_host: 10.0.17.36
-          baremetal_ip: 192.12.185.146
-          baremetal_mac: d4:ae:52:98:15:0f
-          provisioning_mac: d4:ae:52:98:15:0d
-        openshift-master-2.cnv2.massopen.cloud:
-          ipmi_host: 10.0.3.6
-          baremetal_ip: 192.12.185.147
-          baremetal_mac: 90:b1:1c:21:af:4a
-          provisioning_mac: 90:b1:1c:21:af:48
-        openshift-worker-0.cnv2.massopen.cloud:
-          ipmi_host: 10.0.3.5
-          baremetal_ip: 192.12.185.148
-          baremetal_mac: d4:ae:52:98:22:27
-          provisioning_mac: d4:ae:52:98:22:25
-        openshift-worker-1.cnv2.massopen.cloud:
-          ipmi_host: 10.0.17.38
-          baremetal_ip: 192.12.185.149
-          baremetal_mac: 90:b1:1c:21:96:3b
-          provisioning_mac: 90:b1:1c:21:96:39
+      children:
+        controllers:
+          hosts:
+            openshift-master-0.cnv2.massopen.cloud:
+              ipmi_host: 10.0.15.2
+              baremetal_ip: 192.12.185.145
+              baremetal_mac: d4:ae:52:94:d5:a5
+              provisioning_mac: d4:ae:52:94:d5:a3
+            openshift-master-1.cnv2.massopen.cloud:
+              ipmi_host: 10.0.17.36
+              baremetal_ip: 192.12.185.146
+              baremetal_mac: d4:ae:52:98:15:0f
+              provisioning_mac: d4:ae:52:98:15:0d
+            openshift-master-2.cnv2.massopen.cloud:
+              ipmi_host: 10.0.3.6
+              baremetal_ip: 192.12.185.147
+              baremetal_mac: 90:b1:1c:21:af:4a
+              provisioning_mac: 90:b1:1c:21:af:48
+        workers:
+          hosts:
+            openshift-worker-0.cnv2.massopen.cloud:
+              ipmi_host: 10.0.3.5
+              baremetal_ip: 192.12.185.148
+              baremetal_mac: d4:ae:52:98:22:27
+              provisioning_mac: d4:ae:52:98:22:25
+            openshift-worker-1.cnv2.massopen.cloud:
+              ipmi_host: 10.0.17.38
+              baremetal_ip: 192.12.185.149
+              baremetal_mac: 90:b1:1c:21:96:3b
+              provisioning_mac: 90:b1:1c:21:96:39

--- a/hosts.yml
+++ b/hosts.yml
@@ -12,7 +12,7 @@ all:
         ansible_user: kni
         manage_dns: true
       hosts:
-        provisioner.cnv2.massopen.cloud:
+        provisioner.moc-infra.massopen.cloud:
           pxe: true
           ipmi_host: 10.0.5.13
           baremetal_ip: "192.12.185.140/24"
@@ -26,30 +26,30 @@ all:
       children:
         controllers:
           hosts:
-            openshift-master-0.cnv2.massopen.cloud:
+            os-ctrl-0.moc-infra.massopen.cloud:
               ipmi_host: 10.0.15.2
               baremetal_ip: 192.12.185.145
               baremetal_mac: d4:ae:52:94:d5:a5
               provisioning_mac: d4:ae:52:94:d5:a3
-            openshift-master-1.cnv2.massopen.cloud:
+            os-ctrl-1.moc-infra.massopen.cloud:
               ipmi_host: 10.0.17.36
               baremetal_ip: 192.12.185.146
               baremetal_mac: d4:ae:52:98:15:0f
               provisioning_mac: d4:ae:52:98:15:0d
-            openshift-master-2.cnv2.massopen.cloud:
+            os-ctrl-2.moc-infra.massopen.cloud:
               ipmi_host: 10.0.3.6
               baremetal_ip: 192.12.185.147
               baremetal_mac: 90:b1:1c:21:af:4a
               provisioning_mac: 90:b1:1c:21:af:48
-        workers:
-          hosts:
-            openshift-worker-0.cnv2.massopen.cloud:
-              ipmi_host: 10.0.3.5
-              baremetal_ip: 192.12.185.148
-              baremetal_mac: d4:ae:52:98:22:27
-              provisioning_mac: d4:ae:52:98:22:25
-            openshift-worker-1.cnv2.massopen.cloud:
-              ipmi_host: 10.0.17.38
-              baremetal_ip: 192.12.185.149
-              baremetal_mac: 90:b1:1c:21:96:3b
-              provisioning_mac: 90:b1:1c:21:96:39
+#        workers:
+#          hosts:
+#            openshift-worker-0.moc-infra.massopen.cloud:
+#              ipmi_host: 10.0.3.5
+#              baremetal_ip: 192.12.185.148
+#              baremetal_mac: d4:ae:52:98:22:27
+#              provisioning_mac: d4:ae:52:98:22:25
+#            openshift-worker-1.moc-infra.massopen.cloud:
+#              ipmi_host: 10.0.17.38
+#              baremetal_ip: 192.12.185.149
+#              baremetal_mac: 90:b1:1c:21:96:3b
+#              provisioning_mac: 90:b1:1c:21:96:39


### PR DESCRIPTION
update domain name and hostnames for cnv2 -> moc-infra

- update the hostnames for the cnv2 controllers:

  ```
  openshift-master-0.cnv2.massopen.cloud -> os-ctrl-0.moc-infra.massopen.cloud
  openshift-master-1.cnv2.massopen.cloud -> os-ctrl-1.moc-infra.massopen.cloud
  openshift-master-2.cnv2.massopen.cloud -> os-ctrl-2.moc-infra.massopen.cloud
  ```

- drop the worker nodes from the configuration
